### PR TITLE
Add tota11y for accessibility testing

### DIFF
--- a/index.html
+++ b/index.html
@@ -107,6 +107,7 @@
             }
         </style>
         <myuw-app-bar 
+            role="toolbar"
             theme-name="MyUW" 
             theme-url="https://my.wisc.edu" 
             app-name="Bucky Backup">
@@ -132,21 +133,21 @@
                 <div class="demo__grid-box">
                     <form name="testPortalNameChange">
                         <label for="newPortalName">Update portal name:</label>
-                        <input name="newPortalName" type="text" placeholder="New portal name"/>
+                        <input id="newPortalName" type="text" placeholder="New portal name"/>
                         <button onclick="testUpdate(event, 'theme-name',  newPortalName.value)">Update</button>
                     </form>
                 </div>
                 <div class="demo__grid-box">
                     <form name="testAppNameChange">
                         <label for="newAppName">Update app name:</label>
-                        <input name="newAppName" type="text" placeholder="New app name"/>
+                        <input id="newAppName" type="text" placeholder="New app name"/>
                         <button onclick="testUpdate(event, 'app-name',  newAppName.value)">Update</button>
                     </form>
                 </div>
                 <div class="demo__grid-box">
                     <form name="testBackgroundChange">
                         <label for="newBackground">Update background color:</label>
-                        <input name="newBackground" type="text" placeholder="rgb(33,150,243)"/>
+                        <input id="newBackground" type="text" placeholder="rgb(33,150,243)"/>
                         <button onclick="testAddCss(event, 'myuw-app-bar-bg',  newBackground.value)">Update</button>
                     </form>
                 </div>
@@ -155,6 +156,7 @@
                 <div class="demo__grid-box">Box 6</div>
             </div>
         </div>
+        <script src="./node_modules/tota11y/build/tota11y.min.js"></script>
     </body>
     <script>
         /**

--- a/myuw-app-bar.html
+++ b/myuw-app-bar.html
@@ -181,8 +181,9 @@
                     this.shadowRoot.getElementById('myuw-app-bar').classList.remove('shadow');
                 }
             });
-
-            this.updateComponent();
+            
+            var myuwAppBarTitleHtml = this.buildTitleString();
+            this.updateComponent(myuwAppBarTitleHtml);
         }
 
         /**
@@ -197,13 +198,15 @@
         /**
         *   Assemble the HTML to be used in the top bar <h1> tag based on
         *   whether the requisite properties exist.
+        *   @return {String} htmlString A string for the HTML to add to the shadow DOM
         */
         buildTitleString() {
+            
             var htmlString = '';
 
             if (this['theme-name'] !== null) {
                 if (this['theme-url'] !== null) {
-                    htmlString += '<a href="' + this['theme-url'] + '" target="_self">'
+                    htmlString += '<a href="' + this['theme-url'] + '" target="_self" aria-label="' + this['theme-name'] + '">'
                         + this['theme-name'] + '</a>';
                 } else {
                     htmlString += '<span>' + this['theme-name'] + '</span>';
@@ -213,22 +216,24 @@
             if (this['app-name'] !== null) {
                 htmlString += '&nbsp;';
                 if (this['app-url'] !== null) {
-                    htmlString += '<a href="' + this['app-url'] + '" target="_self">'
+                    htmlString += '<a href="' + this['app-url'] + '" target="_self" aria-label="' + this['app-name'] + '">'
                         + this['app-name'] + '</a>';
                 } else {
-                    htmlString += '<span>' + this['app-name'] + '</span>';
+                    htmlString += '<span tabindex="0" aria-label="' + this['app-name'] + '">' + this['app-name'] + '</span>';
                 }
             }
             
             return htmlString;
+        
         }
 
         /**
         *   Update the component state depending on changed properties
         *   and/or font loading
+        *   @param {String} title A string for the HTML to add to the shadow DOM
         */
-        updateComponent() {
-            this.shadowRoot.getElementById('myuw-app-bar__title').innerHTML = this.buildTitleString();
+        updateComponent(title) {
+            this.shadowRoot.getElementById('myuw-app-bar__title').innerHTML = title;
         }
     }
 

--- a/myuw-app-bar.html
+++ b/myuw-app-bar.html
@@ -182,8 +182,7 @@
                 }
             });
             
-            var myuwAppBarTitleHtml = this.buildTitleString();
-            this.updateComponent(myuwAppBarTitleHtml);
+            this.updateComponent();
         }
 
         /**
@@ -212,7 +211,7 @@
                     htmlString += '<span>' + this['theme-name'] + '</span>';
                 }
             }
-
+            
             if (this['app-name'] !== null) {
                 htmlString += '&nbsp;';
                 if (this['app-url'] !== null) {
@@ -230,10 +229,9 @@
         /**
         *   Update the component state depending on changed properties
         *   and/or font loading
-        *   @param {String} title A string for the HTML to add to the shadow DOM
         */
-        updateComponent(title) {
-            this.shadowRoot.getElementById('myuw-app-bar__title').innerHTML = title;
+        updateComponent() {
+            this.shadowRoot.getElementById('myuw-app-bar__title').innerHTML = this.buildTitleString();
         }
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1202,7 +1202,8 @@
     "tota11y": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/tota11y/-/tota11y-0.1.6.tgz",
-      "integrity": "sha1-MScjYU/5X/u4dOVogElAd0ceFUc="
+      "integrity": "sha1-MScjYU/5X/u4dOVogElAd0ceFUc=",
+      "dev": true
     },
     "toxic": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1199,6 +1199,11 @@
       "integrity": "sha1-lYYL/MXHbCd/j4Mm/Q9bLiDrohc=",
       "dev": true
     },
+    "tota11y": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/tota11y/-/tota11y-0.1.6.tgz",
+      "integrity": "sha1-MScjYU/5X/u4dOVogElAd0ceFUc="
+    },
     "toxic": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/toxic/-/toxic-1.0.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@myuw-web-components/myuw-app-bar",
-  "version": "1.1.4",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myuw-web-components/myuw-app-bar",
-  "version": "1.1.4",
+  "version": "1.2.0",
   "description": "A material top app bar designed for use with other MyUW web components",
   "main": "myuw-app-bar.html",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -18,5 +18,8 @@
   "homepage": "https://github.com/myuw-web-components/myuw-app-bar#readme",
   "devDependencies": {
     "superstatic": "^5.0.1"
+  },
+  "dependencies": {
+    "tota11y": "^0.1.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,9 +17,7 @@
   },
   "homepage": "https://github.com/myuw-web-components/myuw-app-bar#readme",
   "devDependencies": {
-    "superstatic": "^5.0.1"
-  },
-  "dependencies": {
+    "superstatic": "^5.0.1",
     "tota11y": "^0.1.6"
   }
 }


### PR DESCRIPTION
**In this PR**:
- Added [tota11y ](https://khan.github.io/tota11y/) as a project dependency and included in demo page
- Added labels to demo page input fields
- Added aria-labels to markup for the app bar title
- Changed when the call to build the title HTML happens (to avoid calling it multiple times)

*Note: VoiceOver on mac is able to read and interact with the app bar as you would expect.*

### Screenshot
![screen shot 2018-07-11 at 10 36 46 am](https://user-images.githubusercontent.com/5818702/42583338-5d271b8c-84f6-11e8-91b4-9ba0923c5e63.png)
