### PR TITLE
use css properties in app bar children

### DIFF
--- a/src/myuw-app-bar.html
+++ b/src/myuw-app-bar.html
@@ -21,7 +21,8 @@
         font-size: 14px;
         font-weight: 500;
         -webkit-font-smoothing: antialiased;
-        background-color: inherit;
+        background-color: var(--myuw-app-bar-bg, inherit);
+        color: var(--myuw-app-bar-color, inherit);
         z-index: 80;
         width: 100%;
         height: 64px;

--- a/src/myuw-app-bar.html
+++ b/src/myuw-app-bar.html
@@ -21,8 +21,8 @@
         font-size: 14px;
         font-weight: 500;
         -webkit-font-smoothing: antialiased;
-        background-color: var(--myuw-app-bar-bg, inherit);
-        color: var(--myuw-app-bar-color, inherit);
+        background-color: var(--myuw-app-bar-bg, var( --myuw-primary-bg, #c5050c));
+        color: var(--myuw-app-bar-color, var(--myuw-primary-color, #fff));
         z-index: 80;
         width: 100%;
         height: 64px;


### PR DESCRIPTION
Even with polyfills, Firefox doesn't seem to want to let the app bar's children inherit its CSS properties. This PR just explicitly sets those properties and falls back on inheritance (which it should never need).