### PR TITLE
Add layout regions and Firefox compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /node_modules/**
 dist
 demo
+.DS_Store

--- a/index.html
+++ b/index.html
@@ -10,9 +10,15 @@
         <script type="module" src="./dist/myuw-app-bar.mjs"></script>
         <script nomodule src="./dist/myuw-app-bar.js"></script>
 
+        <!-- Profile component -->
         <script type="module" src="https://unpkg.com/@myuw-web-components/myuw-profile@^1?module"></script>
         <script nomodule src="https://unpkg.com/@myuw-web-components/myuw-profile@^1"></script>
 
+        <!-- Search component -->
+        <script type="module" src="https://unpkg.com/@myuw-web-components/myuw-search@^1?module"></script>
+        <script nomodule scr="https://unpkg.com/@myuw-web-components/myuw-search@^1"></script>
+
+        <!-- App styles component -->
         <script type="module" src="https://unpkg.com/@myuw-web-components/myuw-app-styles@^1?module"></script>
         <script nomodule src="https://unpkg.com/@myuw-web-components/myuw-app-styles@^1"></script>
     </head>
@@ -111,6 +117,9 @@
                 display: block;
                 flex: auto;
             }
+            myuw-search {
+                /* max-width: 400px; */
+            }
         </style>
         <myuw-app-bar
             role="toolbar"
@@ -122,9 +131,11 @@
                     <i class="material-icons">menu</i>
                 </button>
             </span>
-            <span slot="myuw-search">
-                SEARCH BAR HERE
-            </span>
+            <myuw-search slot="myuw-search"
+                input-label="Search components"
+                button-label="Submit search"
+                icon="search">
+            </myuw-search>
             <span slot="myuw-help">
                 <button class="demo__toolbar-button help">
                     <i class="material-icons">help</i>

--- a/index.html
+++ b/index.html
@@ -7,8 +7,15 @@
             }
         </style>
 
+        <!-- Polyfill loader -->
+        <script src="https://unpkg.com/@webcomponents/webcomponentsjs@2.0.0/webcomponents-bundle.js"></script>
+
         <script type="module" src="./dist/myuw-app-bar.mjs"></script>
         <script nomodule src="./dist/myuw-app-bar.js"></script>
+
+        <!-- Drawer component -->
+        <script type="module" src="https://unpkg.com/@myuw-web-components/myuw-drawer@^1?module"></script>
+        <script nomodule src="https://unpkg.com/@myuw-web-components/myuw-drawer@^1"></script>
 
         <!-- Profile component -->
         <script type="module" src="https://unpkg.com/@myuw-web-components/myuw-profile@^1?module"></script>
@@ -117,20 +124,13 @@
                 display: block;
                 flex: auto;
             }
-            myuw-search {
-                /* max-width: 400px; */
-            }
         </style>
         <myuw-app-bar
             role="toolbar"
             theme-name="MyUW"
             theme-url="https://my.wisc.edu"
             app-name="Bucky Backup">
-            <span slot="myuw-navigation">
-                <button class="demo__toolbar-button menu">
-                    <i class="material-icons">menu</i>
-                </button>
-            </span>
+            <myuw-drawer slot="myuw-navigation"></myuw-drawer>
             <myuw-search slot="myuw-search"
                 input-label="Search components"
                 button-label="Submit search"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@myuw-web-components/myuw-app-bar",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myuw-web-components/myuw-app-bar",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "A material top app bar designed for use with other MyUW web components",
   "module": "dist/myuw-app-bar.min.mjs",
   "browser": "dist/myuw-app-bar.min.js",

--- a/src/myuw-app-bar.html
+++ b/src/myuw-app-bar.html
@@ -65,11 +65,26 @@
         justify-content: flex-start;
     }
 
-    #region__navigation {
+    #region__left, 
+    #region__right {
+        -webkit-box-flex: 1;
+        -webkit-flex: 1 1 30%;
+        flex: 1 1 30%;
+        box-sizing: border-box;
+        max-width: 30%;
+    }
+
+    #myuw-app-bar #region__right {
+        -webkit-box-pack: end;
+        -webkit-justify-content: flex-end;
+        justify-content: flex-end;
+    }
+
+    #slot__navigation {
         margin-right: 16px;
     }
 
-    #myuw-app-bar #region__search {
+    #myuw-app-bar #region__center {
         display: -webkit-box;
         display: -webkit-flex;
         display: flex;
@@ -79,12 +94,12 @@
         justify-content: center;
     }
 
-    #region__profile {
+    #slot__profile {
         margin-left: 6px;
     }
 
-    #region__notifications,
-    #region__help {
+    #slot__notifications,
+    #slot__help {
         margin: 0 6px;
     }
 
@@ -113,22 +128,26 @@
     }
 </style>
 <div id='myuw-app-bar' class='myuw-app-bar'>
-    <div class='region' id='region__navigation'>
-        <slot id='navigation-slot' name='myuw-navigation' />
+    <div class='region' id='region__left'>
+        <div class='slot' id='slot__navigation'>
+            <slot id='navigation-slot' name='myuw-navigation' />
+        </div>
+        <div id='title'>
+            <h1 id='myuw-app-bar__title'></h1>
+        </div>
     </div>
-    <div id='title'>
-        <h1 id='myuw-app-bar__title'></h1>
-    </div>
-    <div class='region'  id='region__search'>
+    <div class='region'  id='region__center'>
         <slot id='search-slot' name='myuw-search' />
     </div>
-    <div class='region'  id='region__help'>
-        <slot id='help-slot' name='myuw-help' />
-    </div>
-    <div class='region' id='region__notifications'>
-        <slot id='notifications-slot' name='myuw-notifications' />
-    </div>
-    <div class='region' id='region__profile'>
-        <slot id='profile-slot' name='myuw-profile' />
+    <div class='region' id='region__right'>
+        <div class='slot' id='slot__help'>
+            <slot id='help-slot' name='myuw-help' />
+        </div>
+        <div class='slot' id='slot__notifications'>
+            <slot id='notifications-slot' name='myuw-notifications' />
+        </div>
+        <div class='slot' id='slot__profile'>
+            <slot id='profile-slot' name='myuw-profile' />
+        </div>
     </div>
 </div>

--- a/src/myuw-app-bar.html
+++ b/src/myuw-app-bar.html
@@ -1,23 +1,14 @@
 <style>
-    :host {
-        display: block;
+    :host([hidden]) {
+        display: none;
+    }
+
+    #myuw-app-bar {
         position: -webkit-sticky;
         position: sticky;
         top: 0;
         background: var(--myuw-app-bar-bg, var( --myuw-primary-bg, #c5050c));
         font-family: var(--myuw-app-bar-font, var( --myuw-font, Arial, sans-serif));
-        color: var(--myuw-app-bar-color, var(--myuw-primary-color, #fff));
-    }
-
-    :host([hidden]) {
-        display: none;
-    }
-
-    :host([font-loaded]) {
-        color: var(--myuw-app-bar-color, var(--myuw-primary-color, #fff));
-    }
-
-    #myuw-app-bar {
         font-size: 14px;
         font-weight: 500;
         -webkit-font-smoothing: antialiased;


### PR DESCRIPTION
**In this PR:**
- Added container regions to areas of the top bar so that the leftmost elements are always aligned left, center elements are always in the middle, etc.
- Moved `:host` CSS styles into the `id` selector so polyfills work with Firefox
- Added polyfills library to demo page 

### Screenshot (Firefox)
![screen shot 2018-08-24 at 11 25 56 am](https://user-images.githubusercontent.com/5818702/44596051-85663f80-a790-11e8-83ba-ffa6ff324b20.png)
