### PR TITLE
Deprecate "theme-url" property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# myuw-app-bar versions
+
+## 1.5.0
+
+### Changed
+
+* Deprecated support for "theme-url" property for better UX. You can still set a theme name and app name, but now the title only supports a single link.
+
+### How to upgrade
+
+If you are using the recommended version (1^), you don't need to do anything special to get these changes. Upgrading to this version will not cause breaking changes. For implementations that use a "theme-url" property and no "app-url" property, the "theme-url" will be used as the title link. For implementations currently using both, the "app-url" will be favored.
+
+

--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ Use the component's HTML tag wherever you want:
 ```HTML
 <myuw-app-bar
     theme-name="MyUW"
-    theme-url=""
     app-name=""
     app-url=""
 >
@@ -32,9 +31,8 @@ Use the component's HTML tag wherever you want:
 ### Configurable properties via attributes
 
 - **themeName (theme-name):** Sets the theme/portal name (defaults to "MyUW")
-- **themeUrl (theme-url):** Sets then URL to go to when user clicks the theme name
 - **appName (app-name):** Sets the app name (e.g. "Bucky Backup")
-- **appUrl (app-url):** Sets then URL to go to when user clicks the app name
+- **appUrl (app-url):** Sets then URL to go to when user clicks the app title
 
 ### Styling the app bar
 

--- a/index.html
+++ b/index.html
@@ -130,8 +130,8 @@
         <myuw-app-bar
             role="toolbar"
             theme-name="MyUW"
-            theme-url="https://my.wisc.edu"
-            app-name="Bucky Backup">
+            app-name="Bucky Backup"
+            app-url="https://my.wisc.edu">
             <myuw-drawer slot="myuw-navigation"></myuw-drawer>
             <myuw-search slot="myuw-search"
                 input-label="Search components"
@@ -169,12 +169,18 @@
                 </div>
                 <div class="demo__grid-box">
                     <form name="testBackgroundChange">
+                        <label for="newUrl">Update title url:</label>
+                        <input id="newUrl" type="text" placeholder="www.google.com"/>
+                        <button onclick="testUpdate(event, 'app-url',  newUrl.value)">Update</button>
+                    </form>
+                </div>
+                <div class="demo__grid-box">
+                    <form name="testBackgroundChange">
                         <label for="newBackground">Update background color:</label>
                         <input id="newBackground" type="text" placeholder="rgb(33,150,243)"/>
                         <button onclick="testAddCss(event, 'myuw-app-bar-bg',  newBackground.value)">Update</button>
                     </form>
                 </div>
-                <div class="demo__grid-box">Box 4</div>
                 <div class="demo__grid-box">Box 5</div>
                 <div class="demo__grid-box">Box 6</div>
             </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@myuw-web-components/myuw-app-bar",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myuw-web-components/myuw-app-bar",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "description": "A material top app bar designed for use with other MyUW web components",
   "module": "dist/myuw-app-bar.min.mjs",
   "browser": "dist/myuw-app-bar.min.js",

--- a/package.json
+++ b/package.json
@@ -11,9 +11,7 @@
     "start": "run-p watch serve",
     "prepare": "npm run build",
     "pages": "rm -rf demo && mkdir -p demo && cp -r dist demo/ && cp index.html demo/ && gh-pages -d demo --repo git@github.com:myuw-web-components/myuw-app-bar.git",
-    "postpublish": "npm run pages",
-    "version": "git add -A",
-    "postversion": "git push"
+    "postpublish": "npm run pages"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "start": "run-p watch serve",
     "prepare": "npm run build",
     "pages": "rm -rf demo && mkdir -p demo && cp -r dist demo/ && cp index.html demo/ && gh-pages -d demo --repo git@github.com:myuw-web-components/myuw-app-bar.git",
-    "postpublish": "npm run pages"
+    "postpublish": "npm run pages",
+    "version": "git add -A",
+    "postversion": "git push"
   },
   "repository": {
     "type": "git",

--- a/src/myuw-app-bar.html
+++ b/src/myuw-app-bar.html
@@ -112,8 +112,7 @@
     }
 
     #myuw-app-bar__title a:hover,
-    #myuw-app-bar__title a:visited,
-    #myuw-app-bar__title > span:hover {
+    #myuw-app-bar__title a:visited, {
             text-decoration: none;
             cursor: pointer;
             color: inherit;


### PR DESCRIPTION
**In this PR:**
- Use a single URL in the app title (prefers what the "app-url" attribute has been set to)
    - Fall back on "theme-url" to support implementations that use it without an "app-url"
- Build title with HTML elements instead of strings
- Add a change log
- Remove references to "theme-url" in README
- Increment minor version
- Add URL updating to demo page