### PR TITLE
remove strict margins on containers/slots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # myuw-app-bar versions
 
+## 1.5.1
+
+### Changed
+
+* Removed CSS margins on div elements that contains slots so they don't take up space when the slot has no content -- taking the position that margins are the responsibility of the slotted content.
+
 ## 1.5.0
 
 ### Changed

--- a/index.html
+++ b/index.html
@@ -148,7 +148,13 @@
                     <i class="material-icons">notifications</i>
                 </button>
             </span>
-            <myuw-profile slot="myuw-profile" session-endpoint="no-session.json"></myuw-profile>
+            <myuw-profile
+                slot="myuw-profile"
+                session-endpoint="./src/session.json"
+                login-url="login.wisc.edu"
+                logout-url="logout.wisc.edu">
+                <a href="#" slot="nav-item">Test link</a>
+            </myuw-profile>
         </myuw-app-bar>
 
         <div class="demo__container">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@myuw-web-components/myuw-app-bar",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myuw-web-components/myuw-app-bar",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "A material top app bar designed for use with other MyUW web components",
   "module": "dist/myuw-app-bar.min.mjs",
   "browser": "dist/myuw-app-bar.min.js",

--- a/src/myuw-app-bar.html
+++ b/src/myuw-app-bar.html
@@ -71,8 +71,11 @@
         justify-content: flex-end;
     }
 
-    #slot__navigation {
-        margin-right: 16px;
+    #slot__navigation,
+    #slot__help,
+    #slot__notifications,
+    #slot__profile {
+        margin: 0;
     }
 
     #myuw-app-bar #region__center {
@@ -85,19 +88,11 @@
         justify-content: center;
     }
 
-    #slot__profile {
-        margin-left: 6px;
-    }
-
-    #slot__notifications,
-    #slot__help {
-        margin: 0 6px;
-    }
-
     #title {
         height: 100%;
         display: flex;
         align-items: center;
+        margin-left: 8px;
     }
 
     #myuw-app-bar__title {
@@ -118,16 +113,13 @@
             color: inherit;
     }
     @media (max-width: 600px) {
-        #myuw-app-bar {
-            padding-right: 0;
-        }
         #myuw-app-bar #region__left {
             flex: auto;
             max-width: none;
         }
         #myuw-app-bar #region__center {
             max-width: 42px;
-            margin: 0 6px;
+            margin: 0;
             justify-content: flex-end;
         }
         #myuw-app-bar #region__right {

--- a/src/myuw-app-bar.js
+++ b/src/myuw-app-bar.js
@@ -60,6 +60,7 @@ export class MyUWAppBar extends HTMLElement {
         this['app-name']    = this.getAttribute('app-name') || 'Hello World';
         this['theme-name']  = this.getAttribute('theme-name');
 
+        // Set the title on initial load
         this.updateTitle();
 
         // Attach scroll listener


### PR DESCRIPTION
**In this PR**:
- Remove margins on container `<div>` elements so they don't take up space when they have no content
- Margins should instead be the responsibility of the individual components

### Screenshot
<img width="511" alt="screen shot 2018-09-12 at 10 57 12 am" src="https://user-images.githubusercontent.com/5818702/45438095-e0969e00-b67b-11e8-9c14-0255e3cf9a7f.png">
