### PR TITLE
Adds css var for app title font size

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ myuw-app-bar {
     --myuw-app-bar-bg: #fff;
     --myuw-app-bar-color: #c5050c;
     --myuw-app-bar-font: 'Roboto', sans-serif;
+    --myuw-app-bar-title-font-size: 18px;
     --myuw-app-bar-font-weight: 400;
     --theme-text-font-weight: 600;
     --z-index: 56;

--- a/src/myuw-app-bar.html
+++ b/src/myuw-app-bar.html
@@ -96,7 +96,7 @@
     }
 
     #myuw-app-bar__title {
-        font-size: 18px;
+        font-size:  var(--myuw-app-bar-title-font-size, 18px);
         font-weight: 500;
         margin: 0 auto;
     }


### PR DESCRIPTION
Please review and provide any suggestions if I've missed something. The app title is a little too big on mobile for the Course Search & Enroll app as you can see.