### PR TITLE
Use unpkg rather than cdn.my in localhost demo

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,11 +8,11 @@
 
 <script type="module">
 
-  import "https://cdn.my.wisc.edu/@myuw-web-components/myuw-app-styles@latest/myuw-app-styles.min.mjs";
-  import "https://cdn.my.wisc.edu/@myuw-web-components/myuw-drawer@latest/myuw-drawer.min.mjs";
-  import "https://cdn.my.wisc.edu/@myuw-web-components/myuw-notifications@latest/myuw-notifications.min.mjs";
-  import "https://cdn.my.wisc.edu/@myuw-web-components/myuw-profile@latest/myuw-profile.min.mjs";
-  import "https://cdn.my.wisc.edu/@myuw-web-components/myuw-search@latest/myuw-search.min.mjs";
+  import "https://unpkg.com/@myuw-web-components/myuw-app-styles/dist/myuw-app-styles.min.mjs";
+  import "https://unpkg.com/@myuw-web-components/myuw-drawer/dist/myuw-drawer.min.mjs";
+  import "https://unpkg.com/@myuw-web-components/myuw-notifications/dist/myuw-notifications.min.mjs";
+  import "https://unpkg.com/@myuw-web-components/myuw-profile/dist/myuw-profile.min.mjs";
+  import "https://unpkg.com/@myuw-web-components/myuw-search/dist/myuw-search.min.mjs";
 
   import "./dist/myuw-app-bar.mjs";
 


### PR DESCRIPTION
We've switched from relying upon cdn.my to using unpkg with the turndown of IA Jenkins automation for publishing to cdn.my. So update the localhost demo to use unpkg rather than cdn.my.